### PR TITLE
Use Hiera 2.x backend API

### DIFF
--- a/lib/hiera/backend/rspec_backend.rb
+++ b/lib/hiera/backend/rspec_backend.rb
@@ -5,12 +5,11 @@ class Hiera
   module Backend
     # Rspec backend to use let(:hiera_data) in specs
     class Rspec_backend
-      def lookup(key, _, _, _)
-        answer = nil
-        if Thread.current[:rspec_hiera_data]
-          answer = Thread.current[:rspec_hiera_data][key]
+      def lookup(key, _, _, _, _)
+        unless (data = Thread.current[:rspec_hiera_data]) && data.include?(key)
+          throw :no_such_key
         end
-        answer
+        data[key]
       end
     end
   end

--- a/spec/hiera-backend-rspec/rspec_backend_spec.rb
+++ b/spec/hiera-backend-rspec/rspec_backend_spec.rb
@@ -25,11 +25,11 @@ class Hiera
         end
 
         it 'provides a value for a valid key' do
-          expect(subject.lookup('stringval', nil, nil, nil)).to eq 'string'
-          expect(subject.lookup('boolval', nil, nil, nil)).to eq true
-          expect(subject.lookup('numericval', nil, nil, nil)).to eq 42
-          expect(subject.lookup('arrayval', nil, nil, nil)).to eq ['one', 'two']
-          expect(subject.lookup('hashval', nil, nil, nil)).to eq key: 'value'
+          expect(subject.lookup('stringval', nil, nil, nil, nil)).to eq 'string'
+          expect(subject.lookup('boolval', nil, nil, nil, nil)).to eq true
+          expect(subject.lookup('numericval', nil, nil, nil, nil)).to eq 42
+          expect(subject.lookup('arrayval', nil, nil, nil, nil)).to eq ['one', 'two']
+          expect(subject.lookup('hashval', nil, nil, nil, nil)).to eq key: 'value'
         end
 
         describe 'scoped hiera data' do
@@ -42,9 +42,12 @@ class Hiera
           end
 
           it 'scopes data' do
-            expect(subject.lookup('stringval', nil, nil, nil)).to eq nil
-            expect(subject.lookup('boolval', nil, nil, nil)).to eq false
-            expect(subject.lookup('numericval', nil, nil, nil)).to eq Math::PI
+            expect do
+              subject.lookup('stringval', nil, nil, nil, nil)
+            end.to raise_error(/:no_such_key/)
+
+            expect(subject.lookup('boolval', nil, nil, nil, nil)).to eq false
+            expect(subject.lookup('numericval', nil, nil, nil, nil)).to eq Math::PI
           end
         end
       end


### PR DESCRIPTION
Before this commit the rspec backend still used the deprecated Hiera 1.x
backend api that interprets nil values returned by #lookup as a lookup
failure (i.e. it was not possible to use keys with nil values).

The readme for the backend specifically states that it is meant to
interface with Hiera version 3.2.0 so it should not be using 1.x.

This commit changes the arity and semantics of the lookup function to
match that of the 2.x backend API.